### PR TITLE
Add define_index matcher

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
+script: "bundle exec rake neo4j:install[community-2.3.0] neo4j:start default --trace"
 language: ruby
+cache: bundler
+sudo: false
 rvm:
   - 2.2.0
   - 2.3.0

--- a/README.md
+++ b/README.md
@@ -42,10 +42,16 @@ it { is_expected.to define_constraint :name, :unique }
 ```ruby
 it { is_expected.to track_creations } # `created_at`
 it { is_expected.to track_modifications } # `updated_at`
-
 ```
 
-TODO: Put some examples of usage:
-- [ ] define_index
+### `index`
+
+```ruby
+it { is_expected.to define_index(:index_name) }
+```
+
+##TODO
+
+Put some examples of usage:
 - [ ] come_from_model
 - [ ] lead_to_model

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,7 @@
-require "bundler/gem_tasks"
+require 'rake'
+require 'bundler/gem_tasks'
+require 'neo4j-core'
+require 'neo4j/rake_tasks'
 require "rspec/core/rake_task"
 
 task default: :spec

--- a/lib/neo4j/rspec/matchers/properties.rb
+++ b/lib/neo4j/rspec/matchers/properties.rb
@@ -58,6 +58,23 @@ module Neo4j
             "expected the #{model.name} model not to have a #{type} constraint on #{name}"
           end
         end
+
+        matcher :define_index do |name|
+          fail ArgumentError, 'index name should be given' if name.blank?
+
+          match do |model|
+            model.attributes.key?(name.to_s) &&
+              model.declared_properties[name.to_s].index?
+          end
+
+          failure_message do |model|
+            "expected the #{model.class.name} model to have an exact index on #{name} property"
+          end
+
+          failure_message_when_negated do |model|
+            "expected the #{model.class.name} model not to have an exact index on #{name} property"
+          end
+        end
       end
     end
   end

--- a/spec/nodes/person.rb
+++ b/spec/nodes/person.rb
@@ -3,4 +3,8 @@ class Person
   has_many :in, :posts, origin: :author
   has_many :in, :comments, origin: :author
   has_many :in, :written_things, type: false, model_class: [:Post, :Comment]
+
+  property :nickname, index: :exact
+  property :reserved
+  index :reserved
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,39 @@ require "pry"
 
 Dir[File.join(File.dirname(__FILE__), "nodes", "*.rb")].each { |file| require file }
 
+module Neo4jHelpers
+  def server_username
+    ENV['NEO4J_USERNAME'] || 'neo4j'
+  end
+
+  def server_password
+    ENV['NEO4J_PASSWORD'] || 'password'
+  end
+
+  def basic_auth_hash
+    {
+      username: server_username,
+      password: server_password
+    }
+  end
+
+  def server_url
+    ENV['NEO4J_URL'] || 'http://localhost:7474'
+  end
+
+  def create_server_session(options = {})
+    Neo4j::Session.open(:server_db, server_url, { basic_auth: basic_auth_hash }.merge(options))
+  end
+end
+
+
 RSpec.configure do |config|
+  include Neo4jHelpers
+
   config.include Neo4j::RSpec::Matchers
+
+  config.before(:suite) do
+    Neo4j::Session.current.close if Neo4j::Session.current
+    create_server_session
+  end
 end

--- a/spec/unit/properties_spec.rb
+++ b/spec/unit/properties_spec.rb
@@ -26,5 +26,10 @@ RSpec.describe "Property matchers" do
     it { is_expected.not_to track_modifications }
     it { is_expected.not_to track_creations }
   end
+
+  describe Person do
+    it { is_expected.to define_index(:nickname) }
+    it { is_expected.to define_index(:reserved) }
+  end
 end
 


### PR DESCRIPTION
@cheerfulstoic I have faced with an issue while implementing this matcher. Somehow the `index` option is not set on `DeclaredProperty` if I use `index :reserved` DSL. Although when I add an index through `property` method option then all is fine.

I have left failing test in the test suite and have made it pending.

Seems strange for me, maybe I do something wrong.
