### PR TITLE
Allow newer versions of rspec and bring back to 3.0

### DIFF
--- a/neo4j-rspec.gemspec
+++ b/neo4j-rspec.gemspec
@@ -17,5 +17,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "neo4j", ">= 6.0.0"
-  spec.add_dependency "rspec", "~> 3.4"
+  spec.add_dependency "rspec", ">= 3.0"
 end


### PR DESCRIPTION
I'm not sure if the gem supports rspec 3.0, but it would be good to go back as far as we can
