### PR TITLE
Property values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+db

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ end
         it { is_expected.to define_property :general }
         it { is_expected.to define_property :string, :String }
         it { is_expected.to define_property :boolean, :Boolean }
+        it { is_expected.to define_property :boolean, :'Neo4j::Shared::Boolean' }
 - Relationships
 
         it { is_expected.to have_many(:comments) }

--- a/lib/neo4j/rspec/matchers/properties.rb
+++ b/lib/neo4j/rspec/matchers/properties.rb
@@ -31,10 +31,9 @@ module Neo4j
         matcher :define_property do |name, type = nil|
           match do |model|
             name = name.to_s
-            expected_type = -> { type == :Boolean ? Neo4j::Shared::Boolean : Object.const_get(type.to_s) }
 
-            model.class.attributes.key?(name) &&
-                (type.nil? || model.class.attributes[name].type == expected_type.call)
+            expected_type = Neo4j::Shared.const_get(type.to_s) if type
+            model.class.attributes.key?(name) && model.class.attributes[name].type == expected_type
           end
 
           failure_message do |model|

--- a/lib/neo4j/rspec/matchers/properties.rb
+++ b/lib/neo4j/rspec/matchers/properties.rb
@@ -31,14 +31,10 @@ module Neo4j
         matcher :define_property do |name, type = nil|
           match do |model|
             name = name.to_s
-            return false unless model.class.attributes.key?(name)
+            expected_type = -> { type == :Boolean ? Neo4j::Shared::Boolean : Object.const_get(type.to_s) }
 
-            if type
-              nesting = Neo4j::RSpec::Compat.current.property_nesting
-              [nesting, Module].any? { |md| md.constants.any? { |c| type == c } }
-            else
-              true
-            end
+            model.class.attributes.key?(name) &&
+                (type.nil? || model.class.attributes[name].type == expected_type.call)
           end
 
           failure_message do |model|

--- a/spec/unit/properties_spec.rb
+++ b/spec/unit/properties_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe "Property matchers" do
       it { is_expected.to define_property(:title) }
       it { is_expected.to define_property(:description, :String) }
       it { is_expected.to define_property(:published, :Boolean) }
+      it { is_expected.to define_property(:published, :'Neo4j::Shared::Boolean') }
 
       it { is_expected.not_to define_property(:non_existant, :Boolean) }
     end
@@ -17,6 +18,20 @@ RSpec.describe "Property matchers" do
 
     it { is_expected.to track_modifications }
     it { is_expected.to track_creations }
+
+    describe 'negative case' do
+      subject do
+        begin
+          expect(Post.new).to define_property(:description, :Integer)
+        rescue => e
+          e
+        end
+      end
+
+      it 'should fail on invalid property type' do
+        expect { subject }.to raise_error RSpec::Expectations::ExpectationNotMetError
+      end
+    end
   end
 
   describe Comment do

--- a/spec/unit/properties_spec.rb
+++ b/spec/unit/properties_spec.rb
@@ -20,16 +20,11 @@ RSpec.describe "Property matchers" do
     it { is_expected.to track_creations }
 
     describe 'negative case' do
-      subject do
-        begin
-          expect(Post.new).to define_property(:description, :Integer)
-        rescue => e
-          e
-        end
-      end
+      subject { expect(Post.new).to define_property(:description, :Integer) }
 
       it 'should fail on invalid property type' do
-        expect { subject }.to raise_error RSpec::Expectations::ExpectationNotMetError
+        expect { subject }.to raise_error RSpec::Expectations::ExpectationNotMetError,
+                                          'expected the Post model to have a `Integer` property description'
       end
     end
   end


### PR DESCRIPTION
Our team has noticed that in validating the `type` of property definition that if you have the following:

```ruby
class Modely
  include Neo4j::ActiveNode
  property :a_model_string, type: String
end
```

if you try to verify the property type in the specs like so:

```ruby
describe Modely do
  it { is_expected.to define_property(:a_model_string, :Integer)
end
```

That it would be ✅  even though the `type` expected to be defined was not correct on the system under test (the `Modely`). We expect an error message that says:

```
expected the Modely  model to have a `Integer` property a_model_string
```

This was due to `Module` being inclusive on the verification previously which always included those types. In order to correct this we've added some additional logic to "constantize" the `type` that we are passing in to verify it against the actual type that `neo4jrb` uses for the model.

The only caveat with the "constantize" is that `:Boolean` is a special `Neo4j::Shared::Boolean` type so we have to have a special case for that.