### PR TITLE
Fix the scope of the failure_start method

### DIFF
--- a/lib/neo4j/rspec/matchers/relations.rb
+++ b/lib/neo4j/rspec/matchers/relations.rb
@@ -74,10 +74,10 @@ module Neo4j
             end
             msg
           end
+        end
 
-          def failure_start(rel)
-            "expected the #{rel.class.name} relation"
-          end
+        def failure_start(rel)
+          "expected the #{rel.class.name} relation"
         end
       end
     end


### PR DESCRIPTION
This was causing an undefined method error when relationships aren't passing
successfully.

Instead of displaying the expected message within `failure_start`, it was displaying an `undefined method error 'failure_start'` message.