### PR TITLE
Drop unused Travis option sudo: false

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ script:
   - "bundle exec rubocop -D"
 language: ruby
 cache: bundler
-sudo: false
 rvm:
   - 2.3
   - 2.4


### PR DESCRIPTION
  - See https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration for notes about the removal